### PR TITLE
Remove redundant array assignments

### DIFF
--- a/flatqueue.go
+++ b/flatqueue.go
@@ -25,8 +25,10 @@ func (q *FlatQueue) Push(id int, value float64) {
 	pos := q.length
 	q.length++
 
-	q.ids = append(q.ids, id)
-	q.values = append(q.values, value)
+	if q.length > len(q.ids) {
+		q.ids = append(q.ids, id)
+		q.values = append(q.values, value)
+	}
 
 	for pos > 0 {
 		parent := (pos - 1) >> 1

--- a/v2/flatqueue.go
+++ b/v2/flatqueue.go
@@ -18,8 +18,10 @@ func (q *FlatQueue[T, V]) Push(item T, value V) {
 	pos := q.length
 	q.length++
 
-	q.items = append(q.items, item)
-	q.values = append(q.values, value)
+	if q.length > len(q.items) {
+		q.items = append(q.items, item)
+		q.values = append(q.values, value)
+	}
 
 	for pos > 0 {
 		parent := (pos - 1) >> 1


### PR DESCRIPTION
This was fixed in the upstream repo (#11). Go slices still need to grow so we append conditionally.